### PR TITLE
Updated jackson version to 2.X

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,11 +262,11 @@
             </dependency>
 
             <!-- core libraries -->
-			<dependency>
-				<groupId>org.codehaus.jackson</groupId>
-				<artifactId>jackson-mapper-asl</artifactId>
-				<version>1.9.4</version>
-			</dependency>
+	    <dependency>
+		<groupId>com.fasterxml.jackson.core</groupId>
+  		<artifactId>jackson-core</artifactId>
+  		<version>2.7.1</version>
+	    </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>


### PR DESCRIPTION
Update to com.fasterxml jackson as org.codehouse (> 2.0) is deprecated